### PR TITLE
fix(api)!: close oss-issues-api origin bypass — in-worker edge-auth, gate writes

### DIFF
--- a/api/handler.ts
+++ b/api/handler.ts
@@ -7,6 +7,7 @@
 
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi'
 import { cors } from 'hono/cors'
+import { createEdgeAuth, requireUserType } from '@wolffm/worker-utils'
 import type { OSSEnv } from './types'
 import { createReconRoutes } from './recon'
 import { HealthResponseSchema } from './schemas'
@@ -39,6 +40,19 @@ export function createOSSHandler(basePath = '/oss/api') {
 
   // CORS middleware
   app.use('*', cors())
+
+  // Adopt the edge-resolved tier, but only when X-Edge-Auth proves the request
+  // came through edge-router (which strips client-supplied copies first). A
+  // direct *.workers.dev hit carries no secret, so it degrades to `public`.
+  app.use('*', createEdgeAuth())
+
+  // Reads are public (this is a public-facing OSS-triage surface). Writes —
+  // recompute, scrape-complete webhook, claim/unclaim — are not: gate every
+  // mutating method to friend/admin, plus `service` so the scraper's own
+  // scrape-complete + compute calls (X-User-Key = its service key) still pass.
+  // Origin bypass and forged tiers land as `public` here and get 403'd. GET /
+  // HEAD stay public and OPTIONS is left to the CORS middleware above.
+  app.on(['POST', 'PUT', 'PATCH', 'DELETE'], '*', requireUserType(['admin', 'friend', 'service']))
 
   // Health check
   const healthRoute = createRoute({

--- a/api/types.ts
+++ b/api/types.ts
@@ -28,4 +28,10 @@ export interface OSSEnv {
    * oss-issues-api`.
    */
   SCRAPER_USER_KEY?: string
+  /**
+   * Shared secret proving a request arrived via edge-router. createEdgeAuth
+   * trusts the edge-stamped X-Hadoku-Tier only when X-Edge-Auth matches this;
+   * a direct *.workers.dev hit has no valid secret and degrades to `public`.
+   */
+  EDGE_AUTH_SECRET?: string
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolffm/hadoku-aggregator",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "description": "OSS Issue Aggregator - Browse beginner-friendly issues across open source projects",
   "type": "module",
   "packageManager": "pnpm@11.5.0",
@@ -44,6 +44,7 @@
     "@hono/zod-openapi": "^1.1.5",
     "@wolffm/logger": "^1.2.1",
     "@wolffm/prefs-client": "^1.0.2",
+    "@wolffm/worker-utils": "^1.2.12",
     "hono": "^4.11.4",
     "marked": "^17.0.3",
     "zod": "^4.1.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@wolffm/prefs-client':
         specifier: ^1.0.2
         version: 1.0.2(react@19.2.4)(zod@4.3.6)
+      '@wolffm/worker-utils':
+        specifier: ^1.2.12
+        version: 1.2.12(zod@4.3.6)
       hono:
         specifier: ^4.11.4
         version: 4.11.7
@@ -542,66 +545,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -766,6 +782,10 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  '@wolffm/logger@1.2.0':
+    resolution: {integrity: sha512-9pqcvJDxovJM4Oa8HGOJjAsQhLWvKRggCYA/GxLLx4ecL5LfNQ7e0rloGj+7vmPVi99LSKM62bdFLCkqriQ8ow==, tarball: https://npm.pkg.github.com/download/@wolffm/logger/1.2.0/f5273f73dcd94c4a33615068e0710f988a9ad793}
+    engines: {node: '>=18'}
+
   '@wolffm/logger@1.2.1':
     resolution: {integrity: sha512-HTKg6runjmoRdiIuzNaUla/6u9DekPv5j55rG1DoUoYmELC+fAZRbeJxEuag9NMAzqbhHUC/QtDMSiPFQpXyag==, tarball: https://npm.pkg.github.com/download/@wolffm/logger/1.2.1/0b7d17996195ec741784bd89430e4a9d895b519c}
     engines: {node: '>=18'}
@@ -787,6 +807,9 @@ packages:
     peerDependencies:
       '@wolffm/task-ui-components': '*'
       react: ^18.0.0 || ^19.0.0
+
+  '@wolffm/worker-utils@1.2.12':
+    resolution: {integrity: sha512-IKe8vsKwAteIhJA+4fjSoBouzLObtWPYCWe5/1iirObx5m22dOoEXS+OJPXer7f2u/BgSrDDhMhnvVpbyikJEg==, tarball: https://npm.pkg.github.com/download/@wolffm/worker-utils/1.2.12/750d1c9e1f18849583ae7b86fde5b11f53d3e5e2}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2478,6 +2501,8 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  '@wolffm/logger@1.2.0': {}
+
   '@wolffm/logger@1.2.1': {}
 
   '@wolffm/prefs-client@1.0.2(react@19.2.4)(zod@4.3.6)':
@@ -2493,6 +2518,14 @@ snapshots:
     dependencies:
       '@wolffm/task-ui-components': 2.0.1(react@19.2.4)
       react: 19.2.4
+
+  '@wolffm/worker-utils@1.2.12(zod@4.3.6)':
+    dependencies:
+      '@hono/zod-openapi': 1.2.0(hono@4.11.7)(zod@4.3.6)
+      '@wolffm/logger': 1.2.0
+      hono: 4.11.7
+    transitivePeerDependencies:
+      - zod
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:


### PR DESCRIPTION
Same bug class as resume-api (just fixed). The `oss-issues-api` origin (`workers.dev`) is publicly routable and `@wolffm/hadoku-aggregator/api` had **no auth of its own** — and it's *worse* than resume-api was, because `/oss/api/*` isn't even in edge-router's tier manifest, so the write routes were reachable unauthenticated **through hadoku.me too**, not just at the origin.

Confirmed by read-only probe:
```
GET  oss-issues-api.<...>.workers.dev/oss/api/recon/agg/build-status  -> 200
GET  hadoku.me/oss/api/recon/all-scored-issues                        -> 200
```
Exposed writes (no auth anywhere): `POST recon/{slug}/refresh` (burns the service-tier scraper key), `recon/compute-all`, `recon/{slug}/compute`, `recon/scrape-complete`, `recon/{slug}/claim` / `unclaim`.

## Fix

Adopt the ecosystem-canonical `@wolffm/worker-utils` pattern:
```ts
app.use('*', createEdgeAuth())                           // trust X-Hadoku-Tier iff X-Edge-Auth
app.on(['POST','PUT','PATCH','DELETE'], '*', requireUserType(['admin','friend','service']))
```

- **Reads stay public** — this is a public-facing OSS-triage surface (owner's call). Only mutating methods are gated.
- **`service` is included** so the scraper's own `scrape-complete` + `compute` callbacks pass once they send their service key (companion PR: hadoku-scraper#44).
- A direct origin hit or forged `X-Hadoku-Tier` lands as `public` → 403. `EDGE_AUTH_SECRET` is already bound on oss-issues-api.

No edge-router change needed: `authGate` already stamps the tier on every proxied `/oss/api/*` request, and the worker enforces per-method.

## Verification

Typecheck + lint clean. `456/457` api tests pass — the one failure (`production-data.test.ts`, `scoreRepoHealth` viability 28 vs 30 on live fastify data) **fails identically on `main`**, unrelated to this change.

## ⚠️ Deploy order

Merge/deploy **hadoku-scraper#44 first** (teaches the scraper to send its service key), then this. Otherwise there's a window where the scraper's write callbacks 403.

## Root cause

The auth-channel-consolidation audit excused this worker as "no key validation — nothing to do", conflating "holds no key arrays" with "has no protected routes." It had both. (Same faulty row that left resume-api open.)