### PR TITLE
feat: adopt unified AppHeader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolffm/hadoku-aggregator",
-  "version": "2.3.12",
+  "version": "2.3.13",
   "description": "OSS Issue Aggregator - Browse beginner-friendly issues across open source projects",
   "type": "module",
   "packageManager": "pnpm@11.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useMemo, useEffect, useCallback } from 'react'
-import { ConnectedThemePicker, LoadingSkeleton } from '@wolffm/task-ui-components'
+import { AppHeader, ConnectedThemePicker, LoadingSkeleton } from '@wolffm/task-ui-components'
 import { THEME_ICON_MAP } from '@wolffm/themes'
 import { useTheme } from './hooks/useTheme'
 import { useAllScoredIssues } from './hooks/useAllScoredIssues'
@@ -269,21 +269,9 @@ export default function App(props: OssAggregatorProps = {}) {
       data-dark-theme={isDarkTheme ? 'true' : 'false'}
     >
       <div className="oss-aggregator">
-        <header className="oss-aggregator__header">
-          <h1 className="oss-aggregator__title">OSS Recon Dashboard</h1>
-
-          <div className="oss-aggregator__controls">
-            <button
-              className={`refresh-button ${issuesLoading ? 'refresh-button--loading' : ''}`}
-              onClick={() => {
-                void refetch()
-              }}
-              disabled={issuesLoading}
-            >
-              <span className="refresh-button__icon">↻</span>
-              <span>Refresh</span>
-            </button>
-
+        <AppHeader
+          title="OSS Recon Dashboard"
+          themePicker={
             <ConnectedThemePicker
               themeFamilies={THEME_FAMILIES}
               currentTheme={theme}
@@ -293,8 +281,21 @@ export default function App(props: OssAggregatorProps = {}) {
                 return Icon ? <Icon /> : null
               }}
             />
-          </div>
-        </header>
+          }
+        />
+
+        <div className="oss-aggregator__actions">
+          <button
+            className={`refresh-button ${issuesLoading ? 'refresh-button--loading' : ''}`}
+            onClick={() => {
+              void refetch()
+            }}
+            disabled={issuesLoading}
+          >
+            <span className="refresh-button__icon">↻</span>
+            <span>Refresh</span>
+          </button>
+        </div>
 
         <div className="oss-aggregator__body">
           <aside className="oss-aggregator__sidebar">

--- a/src/entry.tsx
+++ b/src/entry.tsx
@@ -5,6 +5,7 @@ import App from './App'
 import '@wolffm/themes/style.css'
 // REQUIRED: Import theme picker CSS
 import '@wolffm/task-ui-components/theme-picker.css'
+import '@wolffm/task-ui-components/app-header.css'
 import './styles/index.css'
 
 // Props interface for configuration from parent app

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -49,30 +49,17 @@
   padding: 1.5rem;
 }
 
-/* Header */
-.oss-aggregator__header {
+/* Header now comes from the shared <AppHeader> (@wolffm/task-ui-components,
+ * app-header.css). The former .oss-aggregator__header / __title / __controls
+ * rules were removed when this app adopted the unified header. */
+
+/* Action bar below the header — hosts the relocated Refresh control. */
+.oss-aggregator__actions {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
   align-items: center;
   gap: 1rem;
+  flex-wrap: wrap;
   margin-bottom: 1.5rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.oss-aggregator__title {
-  margin: 0;
-  color: var(--color-primary);
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-.oss-aggregator__controls {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  flex-wrap: wrap;
 }
 
 /* Body Layout - Sidebar + Main */
@@ -1556,12 +1543,7 @@
     padding: 1rem;
   }
 
-  .oss-aggregator__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .oss-aggregator__controls {
+  .oss-aggregator__actions {
     width: 100%;
     justify-content: space-between;
   }


### PR DESCRIPTION
Adopts the shared `<AppHeader>` from `@wolffm/task-ui-components` (per hadoku-printTool#20).

## What
- Replaces the hand-rolled `.oss-aggregator__header` with `<AppHeader title="OSS Recon Dashboard" themePicker={<ConnectedThemePicker/>} />`.
- The **settings gear** (unified per-user settings: tier · display name · content-visibility · auth-key swap) is auto-injected by `AppHeader` — this app previously had none.
- **Moves the Refresh button OUT of the header** into a new `.oss-aggregator__actions` bar directly below the header, above the dashboard body. The header action bar is theme + settings only; Refresh is an app control, so it now lives in the app body with its `onClick={refetch}` handler and styling preserved exactly.
- Adds `import '@wolffm/task-ui-components/app-header.css'` next to the theme-picker CSS import.
- `@wolffm/task-ui-components` devDependency already at `^2.1.0` on main (auto-update); peerDependency `>=1.0.0` left alone.
- Removes the now-dead `.oss-aggregator__header` / `__title` / `__controls` CSS (desktop + mobile).

## Verification (all pass against published 2.1.0)
- `pnpm typecheck`
- `pnpm lint` (eslint)
- `pnpm lint:css` (stylelint + @wolffm/themes token check — 41 tokens resolve)
- `pnpm build` (vite UI + tsup API)
- `pnpm format:check`