### PR TITLE
Retire raw emoji from the UI

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,10 @@
       "Bash(npm view:*)",
       "Bash(curl:*)",
       "Bash(gh run list:*)",
-      "Bash(gh run view:*)"
+      "Bash(gh run view:*)",
+      "Read(//home/hadoku/repos/hadoku_site/docs/**)",
+      "Read(//home/hadoku/repos/hadoku_site/**)",
+      "Bash(git fetch *)"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolffm/hadoku-aggregator",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "OSS Issue Aggregator - Browse beginner-friendly issues across open source projects",
   "type": "module",
   "packageManager": "pnpm@11.5.0",
@@ -52,7 +52,7 @@
   "peerDependencies": {
     "@wolffm/logger": ">=1.0.0",
     "@wolffm/task-ui-components": ">=3.0.0",
-    "@wolffm/themes": ">=4.0.2",
+    "@wolffm/themes": "^5.5.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/src/components/ErrorState.tsx
+++ b/src/components/ErrorState.tsx
@@ -1,3 +1,5 @@
+import { Icon } from '@wolffm/themes'
+
 interface ErrorStateProps {
   message: string
   onRetry?: () => void
@@ -6,7 +8,9 @@ interface ErrorStateProps {
 export function ErrorState({ message, onRetry }: ErrorStateProps) {
   return (
     <div className="error-state">
-      <div className="error-state__icon">⚠️</div>
+      <div className="error-state__icon">
+        <Icon name="warning" />
+      </div>
       <p className="error-state__message">{message}</p>
       {onRetry && (
         <button className="error-state__retry" onClick={onRetry}>

--- a/src/entry.tsx
+++ b/src/entry.tsx
@@ -3,6 +3,8 @@ import { logger } from '@wolffm/logger/client'
 import App from './App'
 // REQUIRED: Import @wolffm/themes CSS - DO NOT REMOVE
 import '@wolffm/themes/style.css'
+// Icon sizing + accent tiles, unlayered next to style.css (THEME_USAGE_GUIDE).
+import '@wolffm/themes/icons.css'
 // REQUIRED: Import theme picker CSS
 import '@wolffm/task-ui-components/theme-picker.css'
 import '@wolffm/task-ui-components/app-header.css'


### PR DESCRIPTION
Swaps this repo's raw emoji for the enforced icon set in `@wolffm/themes` (bumped to `^5.5.1`), with `icons.css` imported next to `style.css`. `check-icons` clean.

**Ternary pairs convert together.** Where one arm was flagged and the other wasn't (e.g. `⏳` flagged, `✓` not — U+2713 is a text symbol, not Extended_Pictographic), both still move: an SVG beside a text glyph at a different weight looks worse than leaving both alone.

## Verified
Real build, not just the gate — every one of these PRs had a build catch something the gate didn't.