### PR TITLE
Wire the icon gate into lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolffm/hadoku-aggregator",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "OSS Issue Aggregator - Browse beginner-friendly issues across open source projects",
   "type": "module",
   "packageManager": "pnpm@11.5.0",
@@ -30,7 +30,7 @@
     "build": "pnpm build:ui && pnpm build:api",
     "build:ui": "vite build && tsc -p tsconfig.build.json",
     "build:api": "tsup",
-    "lint": "eslint .",
+    "lint": "eslint . && pnpm run lint:icons",
     "lint:fix": "eslint . --fix",
     "lint:css": "stylelint \"src/**/*.css\" && node node_modules/@wolffm/themes/scripts/check-usage.mjs ./src",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
@@ -38,7 +38,8 @@
     "test": "vitest run --config vitest.config.api.ts",
     "test:watch": "vitest --config vitest.config.api.ts",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.api.json --noEmit",
-    "prepare": "husky"
+    "prepare": "husky",
+    "lint:icons": "hadoku-check-icons ."
   },
   "dependencies": {
     "@hono/zod-openapi": "^1.1.5",
@@ -66,7 +67,7 @@
     "@typescript-eslint/parser": "^8.54.0",
     "@vitejs/plugin-react": "^5.1.2",
     "@wolffm/task-ui-components": "^4.6.0",
-    "@wolffm/themes": "^5.6.0",
+    "@wolffm/themes": "^5.7.0",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,10 +56,10 @@ importers:
         version: 5.1.2(vite@7.3.1(yaml@2.8.2))
       '@wolffm/task-ui-components':
         specifier: ^4.6.0
-        version: 4.6.0(@wolffm/themes@5.6.0(@wolffm/prefs-client@1.0.7(react@19.2.4)(zod@4.3.6))(react@19.2.4)(zod@4.3.6))(react@19.2.4)
+        version: 4.6.0(@wolffm/themes@5.7.0(@wolffm/prefs-client@1.0.7(react@19.2.4)(zod@4.3.6))(react@19.2.4)(zod@4.3.6))(react@19.2.4)
       '@wolffm/themes':
-        specifier: ^5.6.0
-        version: 5.6.0(@wolffm/prefs-client@1.0.7(react@19.2.4)(zod@4.3.6))(react@19.2.4)(zod@4.3.6)
+        specifier: ^5.7.0
+        version: 5.7.0(@wolffm/prefs-client@1.0.7(react@19.2.4)(zod@4.3.6))(react@19.2.4)(zod@4.3.6)
       eslint:
         specifier: ^9.39.2
         version: 9.39.2
@@ -799,8 +799,9 @@ packages:
       '@wolffm/themes': '*'
       react: ^18.0.0 || ^19.0.0
 
-  '@wolffm/themes@5.6.0':
-    resolution: {integrity: sha512-1JVdrSQMFAmJ9M+4wUng4KEdyhL/LVWiAp+/mIb0fiaUtbgheVaU86WaTYn84XLnB3/4dxKYQAv5sDcr8Q9NFg==, tarball: https://npm.pkg.github.com/download/@wolffm/themes/5.6.0/5c8bdaa9a665396b3942cb782db30f372d521975}
+  '@wolffm/themes@5.7.0':
+    resolution: {integrity: sha512-0h1mz18Cxj7gI5xN4S/xoo/Bcc10IiJBro9IT43xRwWhAEJdPmMVJUm7/sEaxGFiS88sF3cWLBNOTM0xaoOflQ==, tarball: https://npm.pkg.github.com/download/@wolffm/themes/5.7.0/c64f50ada6f5dd400882777759680eb1509c271a}
+    hasBin: true
     peerDependencies:
       '@wolffm/prefs-client': '*'
       react: ^18.0.0 || ^19.0.0
@@ -2506,12 +2507,12 @@ snapshots:
       react: 19.2.4
       zod: 4.3.6
 
-  '@wolffm/task-ui-components@4.6.0(@wolffm/themes@5.6.0(@wolffm/prefs-client@1.0.7(react@19.2.4)(zod@4.3.6))(react@19.2.4)(zod@4.3.6))(react@19.2.4)':
+  '@wolffm/task-ui-components@4.6.0(@wolffm/themes@5.7.0(@wolffm/prefs-client@1.0.7(react@19.2.4)(zod@4.3.6))(react@19.2.4)(zod@4.3.6))(react@19.2.4)':
     dependencies:
-      '@wolffm/themes': 5.6.0(@wolffm/prefs-client@1.0.7(react@19.2.4)(zod@4.3.6))(react@19.2.4)(zod@4.3.6)
+      '@wolffm/themes': 5.7.0(@wolffm/prefs-client@1.0.7(react@19.2.4)(zod@4.3.6))(react@19.2.4)(zod@4.3.6)
       react: 19.2.4
 
-  '@wolffm/themes@5.6.0(@wolffm/prefs-client@1.0.7(react@19.2.4)(zod@4.3.6))(react@19.2.4)(zod@4.3.6)':
+  '@wolffm/themes@5.7.0(@wolffm/prefs-client@1.0.7(react@19.2.4)(zod@4.3.6))(react@19.2.4)(zod@4.3.6)':
     dependencies:
       '@wolffm/prefs-client': 1.0.7(react@19.2.4)(zod@4.3.6)
       react: 19.2.4


### PR DESCRIPTION
Nothing stopped an emoji coming back — the registry and checker existed, but **no repo ran the checker**, so the next agent to write a button had nothing objecting.

- `lint:icons` (`hadoku-check-icons .`) chained into `lint`
- `@wolffm/themes` → `^5.7.0` — the first release whose tarball actually contains the registry the checker reads, and the first exposing it as a **bin** (the old `node_modules/...` path was wrong for nested packages)

Reminders that cost this migration real time:
- **the gate is a worklist, not proof** — run the build *and* lint
- **some emoji legitimately stay** (text-only attributes, `.textContent`, CSS `content:`, Discord/GitHub payloads) — waive with `/* check-icons-disable-next-line */` and a reason